### PR TITLE
modify UI of the home page

### DIFF
--- a/lib/ui/pages/dish_of_the_day_page.dart
+++ b/lib/ui/pages/dish_of_the_day_page.dart
@@ -21,37 +21,40 @@ class DishOfTheDayPage extends ConsumerWidget {
     final formattedEnglish = DateFormat("EEEE \nd. MMMM").format(time);
 
     return Scaffold(
-      appBar: AppBar(
-        leading: const LanguageDropdownWidget(),
-        title: Padding(
-          padding: const EdgeInsets.only(bottom: 4.0),
-          child: Text(
-            AppLocalizations.of(context)!.localeHelper == "da"
-                ? formattedDanish.substring(0, 1).toUpperCase() +
-                    formattedDanish.substring(1)
-                : formattedEnglish,
-            textAlign: TextAlign.center,
-            //style: Theme.of(context).textTheme.bodyMedium,
-          ),
-        ),
-        centerTitle: true,
-        actions: [
-          IconButton(
-            icon: Icon(
-              Icons.chat_bubble_outline,
-              color: Theme.of(context).colorScheme.primary,
+      appBar: PreferredSize(
+        preferredSize: const Size.fromHeight(kToolbarHeight + 10),
+        child: AppBar(
+          leading: const LanguageDropdownWidget(),
+          title: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 5.0),
+            child: Text(
+              AppLocalizations.of(context)!.localeHelper == "da"
+                  ? formattedDanish.substring(0, 1).toUpperCase() +
+                      formattedDanish.substring(1)
+                  : formattedEnglish,
+              textAlign: TextAlign.center,
+              //style: Theme.of(context).textTheme.bodyMedium,
             ),
-            onPressed: () {
-              showModalBottomSheet<void>(
-                  context: context,
-                  builder: (BuildContext context) {
-                    return CommentPage();
-                  });
-            },
-            padding: const EdgeInsets.only(right: 16.0),
           ),
-        ],
-        automaticallyImplyLeading: false,
+          centerTitle: true,
+          actions: [
+            IconButton(
+              icon: Icon(
+                Icons.chat_bubble_outline,
+                color: Theme.of(context).colorScheme.primary,
+              ),
+              onPressed: () {
+                showModalBottomSheet<void>(
+                    context: context,
+                    builder: (BuildContext context) {
+                      return CommentPage();
+                    });
+              },
+              padding: const EdgeInsets.only(right: 16.0),
+            ),
+          ],
+          automaticallyImplyLeading: false,
+        ),
       ),
       body: RefreshIndicator(
         onRefresh: () async {

--- a/lib/ui/pages/dish_of_the_day_page.dart
+++ b/lib/ui/pages/dish_of_the_day_page.dart
@@ -17,16 +17,23 @@ class DishOfTheDayPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final time = DateTime.now();
-    final formattedDanish = DateFormat("EEEE d. MMMM", 'da_DK').format(time);
-    final formattedEnglish = DateFormat("EEEE d. MMMM").format(time);
+    final formattedDanish = DateFormat("EEEE \nd. MMMM", 'da_DK').format(time);
+    final formattedEnglish = DateFormat("EEEE \nd. MMMM").format(time);
 
     return Scaffold(
       appBar: AppBar(
         leading: const LanguageDropdownWidget(),
-        title: Text(AppLocalizations.of(context)!.localeHelper == "da"
-            ? formattedDanish.substring(0, 1).toUpperCase() +
-                formattedDanish.substring(1)
-            : formattedEnglish),
+        title: Padding(
+          padding: const EdgeInsets.only(bottom: 4.0),
+          child: Text(
+            AppLocalizations.of(context)!.localeHelper == "da"
+                ? formattedDanish.substring(0, 1).toUpperCase() +
+                    formattedDanish.substring(1)
+                : formattedEnglish,
+            textAlign: TextAlign.center,
+            //style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ),
         centerTitle: true,
         actions: [
           IconButton(
@@ -52,41 +59,46 @@ class DishOfTheDayPage extends ConsumerWidget {
               .read(dishOfTheDayControllerProvider.notifier)
               .refetchDishOfTheDay();
         },
-        child: ListView(
-          children: [
-            Center(
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 650),
-                child: Align(
-                  alignment: Alignment.topCenter,
-                  child: switch (ref.watch(servingtimeControllerProvider)) {
-                    AsyncData(:final value) => !value
-                        ? switch (ref.watch(dishOfTheDayControllerProvider)) {
-                            AsyncData(:final value) => value.isNotEmpty
-                                ? FlutterCarousel(
+        child: SingleChildScrollView(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 650),
+            child: Align(
+              alignment: Alignment.topCenter,
+              child: switch (ref.watch(servingtimeControllerProvider)) {
+                AsyncData(:final value) => !value
+                    ? switch (ref.watch(dishOfTheDayControllerProvider)) {
+                        AsyncData(:final value) => value.isNotEmpty
+                            ? Padding(
+                                padding: EdgeInsets.only(
+                                  bottom:
+                                      MediaQuery.paddingOf(context).bottom,
+                                ),
+                                child: FlutterCarousel(
                                     options: FlutterCarouselOptions(
                                       viewportFraction: 1,
-                                      height:
-                                          MediaQuery.of(context).size.height *
-                                              0.92,
+                                      height: MediaQuery.of(context)
+                                              .size
+                                              .height -
+                                          (MediaQuery.paddingOf(context).top +
+                                              MediaQuery.paddingOf(context)
+                                                  .bottom +
+                                              kToolbarHeight),
                                       showIndicator: true,
                                     ),
                                     items: value.map((i) {
                                       return DishDisplayWidget(dish: i);
-                                    }).toList())
-                                : const NoDishWidget(), //NO DISH
-                            AsyncError(:final error) => Text(error.toString()),
-                            _ =>
-                              const Center(child: CircularProgressIndicator())
-                          }
-                        : const ServingEndedWidget(), //ENDED
-                    AsyncError(:final error) => Text(error.toString()),
-                    _ => const Center(child: CircularProgressIndicator())
-                  },
-                ),
-              ),
+                                    }).toList()),
+                              )
+                            : const NoDishWidget(), //NO DISH
+                        AsyncError(:final error) => Text(error.toString()),
+                        _ => const Center(child: CircularProgressIndicator())
+                      }
+                    : const ServingEndedWidget(), //ENDED
+                AsyncError(:final error) => Text(error.toString()),
+                _ => const Center(child: CircularProgressIndicator())
+              },
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/ui/widgets/dish_display_widget.dart
+++ b/lib/ui/widgets/dish_display_widget.dart
@@ -12,6 +12,11 @@ class DishDisplayWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final titleStyle = Theme.of(context).textTheme.displayMedium?.copyWith(
+          color: Colors.white,
+          fontWeight: FontWeight.w700,
+        );
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -19,41 +24,43 @@ class DishDisplayWidget extends StatelessWidget {
           clipBehavior: Clip.none,
           alignment: Alignment.bottomLeft,
           children: [
-            AspectRatio(
-              aspectRatio: 16 / 9,
-              child: Image.network(
-                dish.imageUrl,
-                fit: BoxFit.cover,
-                errorBuilder: (context, error, stackTrace) {
-                  // TODO: Add dummy image...
-                  return Container(
-                    color: Colors.grey,
-                    child: const Center(
-                      child: Icon(
-                        Icons.error_outline,
-                        color: Colors.red,
-                        size: 48.0,
-                      ),
-                    ),
-                  );
-                },
-              ),
+            Column(
+              children: [
+                AspectRatio(
+                  aspectRatio: 4 / 3,
+                  child: Image.network(
+                    dish.imageUrl,
+                    fit: BoxFit.cover,
+                    errorBuilder: (context, error, stackTrace) {
+                      // TODO: Add dummy image...
+                      return Container(
+                        color: Colors.grey,
+                        child: const Center(
+                          child: Icon(
+                            Icons.error_outline,
+                            color: Colors.red,
+                            size: 48.0,
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+                SizedBox(height: (titleStyle?.fontSize ?? 0) + 2),
+              ],
             ),
             if (dish.title.isNotEmpty)
               Align(
                 alignment: Alignment.bottomLeft,
-                child: Opacity(
-                  opacity: 0.5,
-                  child: Container(
-                    width: double.infinity,
-                    color: Colors.black,
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 6.0),
-                      child: DisplayMediumText(
-                        text: dish.title,
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                      ),
+                child: SizedBox(
+                  width: double.infinity,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 6.0),
+                    child: DisplayMediumText(
+                      text: dish.title,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: titleStyle,
                     ),
                   ),
                 ),
@@ -107,7 +114,7 @@ class DishDisplayWidget extends StatelessWidget {
           ),
         ),
         Padding(
-          padding: const EdgeInsets.symmetric(vertical: 48.0),
+          padding: const EdgeInsets.only(bottom: 48.0, top: 8.0),
           child: Center(
             child: SizedBox(
               width: MediaQuery.of(context).size.width * 0.9,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/918f5bce-4351-41e1-94da-7935e91383f2)
This pull request includes several updates to the `DishOfTheDayPage` and `DishDisplayWidget` components to improve layout and styling. The most important changes include modifications to text formatting, layout adjustments for better responsiveness, and styling updates to enhance visual presentation.

### Layout and Formatting Enhancements:

* [`lib/ui/pages/dish_of_the_day_page.dart`](diffhunk://#diff-45766cb50667be6d2746a94ed0fdbea49571e50eb4da4df6689b3f8a469f70aeL20-R36): Adjusted date formatting to include line breaks in both Danish and English formats. Also, added padding to the title and centered the text.
* [`lib/ui/pages/dish_of_the_day_page.dart`](diffhunk://#diff-45766cb50667be6d2746a94ed0fdbea49571e50eb4da4df6689b3f8a469f70aeL55-R62): Replaced `ListView` with `SingleChildScrollView` and `ConstrainedBox` for better layout control and responsiveness.
* [`lib/ui/pages/dish_of_the_day_page.dart`](diffhunk://#diff-45766cb50667be6d2746a94ed0fdbea49571e50eb4da4df6689b3f8a469f70aeL66-R94): Wrapped `FlutterCarousel` in a `Padding` widget to account for bottom padding and adjusted its height calculation to be more dynamic.

### Styling Updates:

* [`lib/ui/widgets/dish_display_widget.dart`](diffhunk://#diff-623795b483853ca6565cb9de5c29673d15afa7c1e2578e98469a35d0e8d1fe77R15-R30): Introduced a new `titleStyle` for the dish title, with white color and bold weight, and adjusted the aspect ratio of the dish image. [[1]](diffhunk://#diff-623795b483853ca6565cb9de5c29673d15afa7c1e2578e98469a35d0e8d1fe77R15-R30) [[2]](diffhunk://#diff-623795b483853ca6565cb9de5c29673d15afa7c1e2578e98469a35d0e8d1fe77R49-R63)
* [`lib/ui/widgets/dish_display_widget.dart`](diffhunk://#diff-623795b483853ca6565cb9de5c29673d15afa7c1e2578e98469a35d0e8d1fe77L110-R117): Modified padding around the dish display widget to improve spacing and alignment.